### PR TITLE
fix: update api base url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npx nuxi generate
         env:
           NITRO_PRESET: github_pages
-          API_BASE: https://content.tcheblock.com/wp/graphql
+          API_BASE: https://content.tchebit.com/wp/graphql
           APP_BASE: https://dionmaicon.github.io
 
       - name: Upload artifact


### PR DESCRIPTION
This pull request makes a small update to the continuous integration workflow by changing the API base URL used during the build process. The new URL points to `https://content.tchebit.com/wp/graphql` instead of the previous endpoint.