### PR TITLE
fix: add explicit imports for PostMapper and PostMetaHead

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -70,6 +70,7 @@
 <script setup lang="ts">
 import type { WPPost, GQPostsResponse } from "~/types/IPost";
 import { gql } from "nuxt-graphql-request/utils";
+import PostMapper from "~/utils/PostMapper";
 
 const { $graphql } = useNuxtApp();
 

--- a/pages/posts/[slug].vue
+++ b/pages/posts/[slug].vue
@@ -33,6 +33,7 @@
 
 <script setup lang="ts">
 import PostMapper from "@/utils/PostMapper";
+import PostMetaHead from "@/utils/PostMetaHead";
 import type { Post, WPPost, GQSinglePostResponse } from "~/types/IPost";
 import hljs from "highlight.js";
 import { useRoute } from "vue-router";


### PR DESCRIPTION
Nuxt auto-import does not resolve class default exports reliably. Adding explicit imports fixes the runtime undefined errors on master.